### PR TITLE
Update login page with optional background image

### DIFF
--- a/css/login.css
+++ b/css/login.css
@@ -1,7 +1,24 @@
-form, input {
-    font-size: 32px;
+html {
+    height: 100%;
+    background-color: rgb(207, 231, 247); /* Fallback to blue if no background image */
+    background-image: url(monpad/images/login-background.jpg);
+    background-position: center center;
+    background-repeat: no-repeat;
+    background-size: cover;
+}
+body {
+    background-color: transparent;
+    background-image: linear-gradient(rgba(0, 60, 100, 1), rgba(0, 60, 100, 0));
+    color: white;
+    margin: 0;
+    padding-bottom: 5vw;
 }
 form {
-    padding-top: 0.25em;
+    padding: 0.5em;
     text-align: center;
+    font-size: 32px; /* Fallback if browser doesn't support vw or max() */
+    font-size: max(5vw, 12px);
+}
+input {
+    font-size: inherit;
 }


### PR DESCRIPTION
Login page now supports an optional background image defined at monpad/images/login-background.jpg.
If this image doesn't exist, CSS will fall back to the fixed background colour.
Also updated font size scaling to work better on a range of screen sizes.