### PR TITLE
Disallow empty usernames

### DIFF
--- a/haskell/src/Monpad.hs
+++ b/haskell/src/Monpad.hs
@@ -133,6 +133,7 @@ loginHtml imageUrl = doctypehtml_ . body_ imageStyle . form_ [action_ $ symbolVa
     imageStyle = maybe [] (pure . style_ . ("background-image: url(" <>) . (<> ")")) imageUrl
 
 mainHtml :: Layouts a b -> Port -> ClientID -> Html ()
+mainHtml _ _ (ClientID "") = loginHtml Nothing
 mainHtml layouts wsPort (ClientID username) = doctypehtml_ $ mconcat
     [ style_ (commonCSS ())
     , style_ (appCSS ())


### PR DESCRIPTION
Well, that was easy. Closes #31.

This implementation just silently keeps the user on the login screen (and deletes the background image, though that's easy enough to fix). We probably want to provide a bit of feedback instead.