### PR TITLE
Reject duplicate usernames

### DIFF
--- a/haskell/monpad.cabal
+++ b/haskell/monpad.cabal
@@ -145,6 +145,7 @@ library
         servant-server ^>= 0.18,
         servant-websockets ^>= 2.0,
         streamly-fsnotify ^>= 1.1.1.0,
+        stm ^>= 2.5,
         transformers-base ^>= 0.4.5.2,
         wai ^>= 3.2.2,
         warp ^>= 3.3.9,

--- a/haskell/src/Monpad.hs
+++ b/haskell/src/Monpad.hs
@@ -148,13 +148,12 @@ loginHtml err imageUrl = doctypehtml_ . body_ imageStyle . form_ [action_ $ symb
     , input_ [type_ "submit", value_ "Go!"]
     ] <> case err of
         Nothing -> []
-        Just EmptyUsername ->
-            [ p_ [ style_ "color: red" ]
-                "Empty usernames are not allowed!"
-            ]
-        Just (DuplicateUsername (ClientID u)) ->
-            [ p_ [ style_ "color: red" ] $
-                "The username " <> fromString (T.unpack u) <> " is already in use!"
+        Just e ->
+            [ p_ [ style_ "color: red" ] case e of
+                EmptyUsername ->
+                    "Empty usernames are not allowed!"
+                (DuplicateUsername (ClientID u)) ->
+                    "The username " <> fromString (T.unpack u) <> " is already in use!"
             ]
   where
     nameBoxId = "name"

--- a/haskell/src/Monpad.hs
+++ b/haskell/src/Monpad.hs
@@ -94,7 +94,7 @@ validateUsername :: MVar (Set ClientID) -> ClientID -> IO (Maybe UsernameError)
 validateUsername users u = eitherToMaybe . swapEither <$> runExceptT do
     when (u == ClientID "") $ throwError EmptyUsername
     isNew <- liftIO $ modifyMVar users $ pure . setInsert' u
-    when isNew . throwError $ DuplicateUsername u
+    unless isNew . throwError $ DuplicateUsername u
 data UsernameError
     = EmptyUsername
     | DuplicateUsername ClientID

--- a/haskell/src/Monpad.hs
+++ b/haskell/src/Monpad.hs
@@ -306,9 +306,9 @@ httpServer wsPort loginImage assetsDir layouts users = core :<|> assets
     core = \case
         Nothing -> pure $ loginHtml Nothing loginImage
         Just u -> -- there is a username query param in the URL
-            liftIO (validateUsername users u) >>= \case
-                Nothing -> pure $ mainHtml layouts wsPort
-                Just err -> pure $ loginHtml (Just err) loginImage
+            liftIO (validateUsername users u) <&> \case
+                Nothing -> mainHtml layouts wsPort
+                Just err -> loginHtml (Just err) loginImage
     assets :: Server AssetsApi
     assets = maybe
         (pure $ const ($ responseLBS status404 [] "no asset directory specified"))

--- a/haskell/src/Monpad.hs
+++ b/haskell/src/Monpad.hs
@@ -320,7 +320,7 @@ httpServer wsPort loginImage assetsDir layouts mclients = core :<|> assets
                     Just Clients{waiting, connected} -> do
                         alreadyConnected <- lift $ Set.member u <$> readTVar connected
                         when alreadyConnected $ throwError $ DuplicateUsername True u
-                        isNew <- lift $ stateTVar waiting $ swap . setInsert' u
+                        isNew <- lift $ stateTVar waiting $ setInsert' u
                         unless isNew $ throwError $ DuplicateUsername False u
                     Nothing -> pure ()
     assets :: Server AssetsApi
@@ -455,9 +455,9 @@ websocketServer pingFrequency layouts ServerConfig{..} clients mu pending = lift
         WS.rejectRequest pending $ encodeUtf8 err
     -- attempt to move client from the waiting set to the connected set
     registerConnection clientId = atomically do
-        success <- stateTVar clients.waiting $ swap . setDelete' clientId
+        success <- stateTVar clients.waiting $ setDelete' clientId
         when success do
-            isNew <- stateTVar clients.connected $ swap . setInsert' clientId
+            isNew <- stateTVar clients.connected $ setInsert' clientId
             unless isNew $ error $ "logic error - username in waiting and connected set: " <> show clientId
         pure success
 

--- a/haskell/src/Util.hs
+++ b/haskell/src/Util.hs
@@ -146,3 +146,11 @@ setInsert' :: Ord a => a -> Set a -> (Set a, Bool)
 setInsert' x s = (s', Set.size s /= Set.size s')
   where
     s' = Set.insert x s
+
+{- | Returns 'True' iff element was present.
+'Set.size' is O(1), so this is quicker than checking membership first.
+-}
+setDelete' :: Ord a => a -> Set a -> (Set a, Bool)
+setDelete' x s = (s', Set.size s /= Set.size s')
+  where
+    s' = Set.delete x s

--- a/haskell/src/Util.hs
+++ b/haskell/src/Util.hs
@@ -21,6 +21,8 @@ import Control.Monad.Trans.Maybe (MaybeT)
 import Data.Either.Validation (validationToEither)
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map qualified as Map
+import Data.Set (Set)
+import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Void (Void)
@@ -135,3 +137,12 @@ uniqueNames l xs = flip evalState allNames $ for xs \x ->
     -- the state map stores the number of occurrences of each name seen so far
     allNames = Map.fromList $ zip (view l <$> toList xs) (repeat (0 :: Int))
     err = error "broken invariant in `uniqueNames` - all names should be in map by construction"
+
+{- | Returns 'True' iff element is new.
+'Set.size' is O(1), so this is quicker than checking membership first.
+--TODO add to `containers`? https://github.com/haskell/containers/issues/31
+-}
+setInsert' :: Ord a => a -> Set a -> (Set a, Bool)
+setInsert' x s = (s', Set.size s /= Set.size s')
+  where
+    s' = Set.insert x s

--- a/haskell/src/Util.hs
+++ b/haskell/src/Util.hs
@@ -142,15 +142,15 @@ uniqueNames l xs = flip evalState allNames $ for xs \x ->
 'Set.size' is O(1), so this is quicker than checking membership first.
 --TODO add to `containers`? https://github.com/haskell/containers/issues/31
 -}
-setInsert' :: Ord a => a -> Set a -> (Set a, Bool)
-setInsert' x s = (s', Set.size s /= Set.size s')
+setInsert' :: Ord a => a -> Set a -> (Bool, Set a)
+setInsert' x s = (Set.size s /= Set.size s', s')
   where
     s' = Set.insert x s
 
 {- | Returns 'True' iff element was present.
 'Set.size' is O(1), so this is quicker than checking membership first.
 -}
-setDelete' :: Ord a => a -> Set a -> (Set a, Bool)
-setDelete' x s = (s', Set.size s /= Set.size s')
+setDelete' :: Ord a => a -> Set a -> (Bool, Set a)
+setDelete' x s = (Set.size s /= Set.size s', s')
   where
     s' = Set.delete x s


### PR DESCRIPTION
We can't merge this right now since we don't always/ever fire `onDroppedConnection` due to these issues:
- https://github.com/composewell/streamly/issues/1203 (see the commit message of 95af2c3)
- #22 

Thus we don't actually delete from the set of active users, and therefore if a user tries to reconnect, they'll be rejected as the username will appear to be a duplicate.

Also note that the set is essentially unused in `serverExtWs` (even though we initialise it with `users <- newMVar Set.empty` since it's never added to. Perhaps we can refactor.